### PR TITLE
Integrate phi4 14B model with AINZUNI.html

### DIFF
--- a/AINZUNI Website/AINZUNI.html
+++ b/AINZUNI Website/AINZUNI.html
@@ -385,53 +385,98 @@
                 menu.style.display = 'none';
             }
         });
-  // Map your existing elements. Change selectors to match your page.
-  const form = document.querySelector('#chat-form');  // Your message form
-  const input = document.querySelector('#prompt');    // Your text input
-  const messages = document.querySelector('#messages'); // Your chat container
 
-  // Keep a running chat context so the model sees history.
-  const conversation = [];
+        // ===== AINZUNI Chat: Real-time streaming with Phi-4 14B via local backend =====
+        const chatMessagesEl = document.getElementById('chat-messages');
+        const chatInputEl = document.getElementById('chat-input');
+        const conversation = [];
 
-  // Small helper to show messages in your chat box.
-  function append(role, text) {
-    const div = document.createElement('div');
-    div.className = role;              // e.g., "user" or "assistant" for styling
-    div.textContent = text;            // show the text
-    messages.appendChild(div);         // add to chat
-    messages.scrollTop = messages.scrollHeight; // scroll to bottom
-  }
+        function appendMessage(role, text) {
+            const p = document.createElement('p');
+            p.textContent = text;
+            p.style.whiteSpace = 'pre-wrap';
+            p.style.margin = '8px 0';
+            if (role === 'user') {
+                p.style.fontWeight = '600';
+            }
+            chatMessagesEl.appendChild(p);
+            chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+            return p;
+        }
 
-  // Send the prompt to the model via Ollama's chat API.
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();                      // stop page reload
-    const text = input.value.trim();         // read what you typed
-    if (!text) return;                       // ignore empty
-    append('user', text);                    // show your message immediately
-    input.value = '';                        // clear the input
+        async function sendMessage() {
+            const text = chatInputEl.value.trim();
+            if (!text) return;
+            appendMessage('user', text);
+            chatInputEl.value = '';
 
-    // Add your message to the model's conversation context.
-    conversation.push({ role: 'user', content: text });
+            conversation.push({ role: 'user', content: text });
 
-    try {
-      const resp = await fetch('http://127.0.0.1:11434/api/chat', {
-        method: 'POST',                                      // chat is a POST
-        headers: { 'Content-Type': 'application/json' },     // send JSON
-        body: JSON.stringify({
-          model: '',                                 // your model name
-          messages: conversation,                            // full chat history
-          stream: false                                      // one complete reply
-        })
-      });
+            // Placeholder assistant message that we'll stream into
+            const assistantEl = appendMessage('assistant', 'AINZUNI is thinking');
+            assistantEl.classList.add('typing');
 
-      const data = await resp.json();                        // parse JSON reply
-      const reply = data?.message?.content ?? '';            // extract assistant text
-      conversation.push({ role: 'assistant', content: reply }); // keep context
-      append('assistant', reply);                            // show the reply
-    } catch (err) {
-      append('assistant', 'Error: ' + err.message);          // show any error
-    }
-  })
+            try {
+                // Talk to our Flask backend which proxies to Ollama with NDJSON streaming
+                const resp = await fetch('http://127.0.0.1:5000/api/chat', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        model: 'phi4:14b',
+                        messages: conversation,
+                        stream: true
+                    })
+                });
+
+                if (!resp.ok) {
+                    const errText = await resp.text();
+                    assistantEl.textContent = 'Error: ' + errText;
+                    assistantEl.classList.remove('typing');
+                    return;
+                }
+
+                const reader = resp.body.getReader();
+                const decoder = new TextDecoder('utf-8');
+                let buffer = '';
+                let finalText = '';
+
+                while (true) {
+                    const { value, done } = await reader.read();
+                    if (done) break;
+                    buffer += decoder.decode(value, { stream: true });
+
+                    let newlineIndex;
+                    while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
+                        const line = buffer.slice(0, newlineIndex).trim();
+                        buffer = buffer.slice(newlineIndex + 1);
+                        if (!line) continue;
+                        try {
+                            const json = JSON.parse(line);
+                            // Ollama chat stream yields partial chunks in json.message.content
+                            const chunk = json?.message?.content ?? '';
+                            if (chunk) {
+                                finalText += chunk;
+                                assistantEl.textContent = finalText;
+                                chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+                            }
+                            if (json?.done) {
+                                conversation.push({ role: 'assistant', content: finalText });
+                            }
+                        } catch (e) {
+                            // Ignore non-JSON lines safely
+                        }
+                    }
+                }
+
+                assistantEl.classList.remove('typing');
+                if (!finalText) {
+                    assistantEl.textContent = 'No response received.';
+                }
+            } catch (err) {
+                assistantEl.textContent = 'Error: ' + (err?.message || String(err));
+                assistantEl.classList.remove('typing');
+            }
+        }
     </script>
 </body>
 </html>

--- a/phi_server.py
+++ b/phi_server.py
@@ -1,0 +1,112 @@
+import os
+import json
+from typing import Iterator
+
+import requests
+from flask import Flask, request, Response, jsonify
+from flask_cors import CORS
+from werkzeug.exceptions import BadRequest
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+    CORS(app, resources={r"/api/*": {"origins": "*"}})
+
+    ollama_base_url = os.environ.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434").rstrip("/")
+    default_model = os.environ.get("MODEL_NAME", "phi4:14b")
+
+    @app.get("/api/status")
+    def status():
+        ok = True
+        ollama_ok = False
+        models = []
+        try:
+            tags_resp = requests.get(f"{ollama_base_url}/api/tags", timeout=5)
+            if tags_resp.ok:
+                ollama_ok = True
+                tags = tags_resp.json().get("models", [])
+                models = [m.get("name") for m in tags if m.get("name")]
+        except Exception:
+            ok = False
+        return jsonify({
+            "ok": ok and ollama_ok,
+            "ollama_ok": ollama_ok,
+            "ollama_base_url": ollama_base_url,
+            "models": models,
+            "default_model": default_model,
+        })
+
+    @app.get("/api/models")
+    def list_models():
+        try:
+            tags_resp = requests.get(f"{ollama_base_url}/api/tags", timeout=5)
+            tags_resp.raise_for_status()
+            data = tags_resp.json()
+            return jsonify(data)
+        except Exception as exc:
+            return jsonify({"error": str(exc)}), 502
+
+    @app.post("/api/chat")
+    def chat_stream():
+        try:
+            payload = request.get_json(force=True, silent=False) or {}
+        except BadRequest:
+            return jsonify({"error": "Invalid JSON body"}), 400
+
+        messages = payload.get("messages", [])
+        model = payload.get("model") or default_model
+        stream = payload.get("stream", True)
+        options = payload.get("options") or {}
+
+        if not isinstance(messages, list) or not messages:
+            return jsonify({"error": "'messages' must be a non-empty list"}), 400
+
+        upstream_url = f"{ollama_base_url}/api/chat"
+        upstream_body = {
+            "model": model,
+            "messages": messages,
+            "stream": True if stream else False,
+        }
+        if options:
+            upstream_body["options"] = options
+
+        headers = {"Content-Type": "application/json"}
+
+        if stream:
+            def generate() -> Iterator[str]:
+                with requests.post(upstream_url, data=json.dumps(upstream_body), headers=headers, stream=True, timeout=(10, 600)) as r:
+                    r.raise_for_status()
+                    for line in r.iter_lines(decode_unicode=True):
+                        if not line:
+                            continue
+                        # Forward NDJSON line-by-line to the client
+                        yield line + "\n"
+
+            return Response(generate(), mimetype="application/x-ndjson")
+        else:
+            try:
+                r = requests.post(upstream_url, data=json.dumps(upstream_body), headers=headers, timeout=600)
+                r.raise_for_status()
+                return jsonify(r.json())
+            except requests.RequestException as exc:
+                return jsonify({"error": str(exc)}), 502
+
+    @app.get("/")
+    def root():
+        return jsonify({
+            "message": "AINZUNI Phi-4 backend is running",
+            "endpoints": ["GET /api/status", "GET /api/models", "POST /api/chat"],
+            "model": default_model,
+        })
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("FLASK_PORT", "5000"))
+    # threaded=True allows one request to stream while others still respond
+    app.run(host="0.0.0.0", port=port, debug=False, threaded=True)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+flask-cors==4.0.0
+requests==2.32.3


### PR DESCRIPTION
Integrate real-time streaming answers from a local Phi-4 14B model (via Ollama) into `AINZUNI.html` by adding a Flask backend and updating the frontend for streaming.

The original `AINZUNI.html` had placeholder chat functionality. This PR introduces a dedicated Flask backend (`phi_server.py`) to proxy requests to a local Ollama instance, enabling real-time, token-by-token streaming of responses. The frontend (`AINZUNI.html`) was updated to consume this NDJSON stream, providing a dynamic chat experience. This setup decouples the UI from direct Ollama interaction, handles CORS, and ensures a responsive user interface during model inference.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7725b06-794b-4060-a162-966513a92d02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7725b06-794b-4060-a162-966513a92d02">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

